### PR TITLE
Composer generation: support for arbitrary folder structure of repositories

### DIFF
--- a/src/Command/Dev/UpdateComposer.php
+++ b/src/Command/Dev/UpdateComposer.php
@@ -117,8 +117,8 @@ class UpdateComposer extends Command
         $composer = $this->composerGenerator->generate($gitOptions['repositories']);
 
         if (!empty($gitOptions['clear_magento_module_requirements'])) {
-            $this->clearModuleRequirements->generate($gitOptions['repositories']);
-            $composer['scripts']['install-from-git'][] = 'php ' . ClearModuleRequirements::SCRIPT_PATH;
+            $clearRequirementsScript = $this->clearModuleRequirements->generate();
+            $composer['scripts']['install-from-git'][] = 'php ' . $clearRequirementsScript;
         }
 
         $this->file->filePutContents(

--- a/src/Command/Dev/UpdateComposer/ComposerGenerator.php
+++ b/src/Command/Dev/UpdateComposer/ComposerGenerator.php
@@ -17,8 +17,6 @@ use Magento\MagentoCloud\Package\MagentoVersion;
  */
 class ComposerGenerator
 {
-    const REPO_TYPE_SINGLE_PACKAGE = 'single-package';
-
     /**
      * @var DirectoryList
      */
@@ -197,6 +195,7 @@ class ComposerGenerator
      *
      * @param string $path
      * @return array
+     * @throws FileSystemException
      */
     private function findPackages(string $path) {
         $path = rtrim($path, '\\/');

--- a/src/Command/Dev/UpdateComposer/ComposerGenerator.php
+++ b/src/Command/Dev/UpdateComposer/ComposerGenerator.php
@@ -11,19 +11,13 @@ use Magento\MagentoCloud\Filesystem\DirectoryList;
 use Magento\MagentoCloud\Filesystem\Driver\File;
 use Magento\MagentoCloud\Filesystem\FileSystemException;
 use Magento\MagentoCloud\Package\MagentoVersion;
-use Magento\MagentoCloud\Package\UndefinedPackageException;
 
 /**
  * Generates composer.json data for installation from git.
  */
 class ComposerGenerator
 {
-    public const REPO_TYPE_SINGLE_PACKAGE = 'single-package';
-
-    /**
-     * Type for packages with modules in the root directory such as Inventory
-     */
-    public const REPO_TYPE_FLAT_STRUCTURE = 'flat-structure';
+    const REPO_TYPE_SINGLE_PACKAGE = 'single-package';
 
     /**
      * @var DirectoryList
@@ -60,9 +54,7 @@ class ComposerGenerator
      *
      * @param array $repoOptions
      * @return array
-     * @throws UndefinedPackageException
      * @throws FileSystemException
-     *
      * @codeCoverageIgnore
      */
     public function generate(array $repoOptions): array
@@ -78,26 +70,37 @@ class ComposerGenerator
             $composer['require'] += ['magento/ece-tools' => '2002.0.*'];
         }
 
-        foreach (array_keys($repoOptions) as $repoName) {
-            $repoComposerJsonPath = $this->directoryList->getMagentoRoot() . '/' . $repoName . '/composer.json';
-            if (!$this->file->isExists($repoComposerJsonPath)) {
-                continue;
+        $preparePackagesScripts = [];
+        foreach ($repoOptions as $repoName => $gitOption) {
+            $baseRepoFolder = $this->directoryList->getMagentoRoot() . '/' . $repoName;
+
+            $dirComposerJson = $baseRepoFolder . '/composer.json';
+            if (file_exists($dirComposerJson)) {
+                $dirPackageInfo = json_decode($this->file->fileGetContents($dirComposerJson), true);
+                if ($dirPackageInfo['type'] == 'project') {
+                    $composer['require'] = array_merge($composer['require'], $dirPackageInfo['require']);
+                }
             }
 
-            $repoComposer = $this->file->fileGetContents($repoComposerJsonPath);
-            $composer['require'] = array_merge(
-                $composer['require'],
-                json_decode($repoComposer, true)['require']
+            $repoPackages = $this->findPackages($baseRepoFolder);
+            foreach ($repoPackages as $packageName => $packagePath) {
+                $composer['repositories'][$packageName] = [
+                    'type' => 'path',
+                    'url' => $repoName . '/' . $packagePath,
+                    'options' => [
+                        'symlink' => false,
+                    ]
+                ];
+                $composer['require'][$packageName] = '*@dev';
+            }
+            $preparePackagesScripts[] = sprintf(
+                "rsync -azhm --stats --exclude='". join("' --exclude='", $repoPackages) ."'"
+                . " --exclude='dev/tests' --exclude='.git' --exclude='composer.json' --exclude='composer.lock' ./%s/ ./",
+                $repoName
             );
         }
-
-        foreach (array_keys($composer['require']) as $packageName) {
-            if (preg_match('/magento\/framework|magento\/module/', $packageName)) {
-                $composer['require'][$packageName] = '*';
-            }
-        }
-
-        $composer = $this->addModules($repoOptions, $composer);
+        $composer['scripts']['prepare-packages'] = $preparePackagesScripts;
+        $composer['scripts']['post-install-cmd'] = ['@prepare-packages'];
 
         return $composer;
     }
@@ -112,13 +115,14 @@ class ComposerGenerator
         $installFromGitScripts[] = 'rm -rf ' . implode(' ', array_keys($repoOptions));
 
         foreach ($repoOptions as $repoName => $gitOption) {
-            $gitCloneCommand = 'git clone -b %s --single-branch --depth 1 %s %s';
-
+            $gitRef = $gitOption['ref'] ?? $gitOption['branch'];
             $installFromGitScripts[] = sprintf(
-                $gitCloneCommand,
-                $gitOption['branch'],
+                'git clone %s "%s" && git --git-dir="%s/.git" --work-tree="%s" checkout %s',
                 $gitOption['repo'],
-                $repoName
+                $repoName,
+                $repoName,
+                $repoName,
+                $gitRef
             );
         }
 
@@ -130,26 +134,10 @@ class ComposerGenerator
      *
      * @param array $repoOptions
      * @return array
-     * @throws UndefinedPackageException
      */
     private function getBaseComposer(array $repoOptions): array
     {
         $installFromGitScripts = $this->getInstallFromGitScripts($repoOptions);
-
-        $preparePackagesScripts = [];
-
-        foreach ($repoOptions as $repoName => $gitOption) {
-            if ($this->isSinglePackage($gitOption) || $this->isFlatStructurePackage($gitOption)) {
-                continue;
-            }
-
-            $preparePackagesScripts[] = sprintf(
-                "rsync -azh --stats --exclude='app/code/Magento/' --exclude='app/i18n/' --exclude='app/design/' "
-                . "--exclude='dev/tests' --exclude='lib/internal/Magento' --exclude='.git' ./%s/ ./",
-                $repoName
-            );
-        }
-
         $composer = [
             'name' => 'magento/cloud-dev',
             'description' => 'eCommerce Platform for Growth',
@@ -192,16 +180,12 @@ class ComposerGenerator
             ],
             'scripts' => [
                 'install-from-git' => $installFromGitScripts,
-                'prepare-packages' => $preparePackagesScripts,
                 'pre-install-cmd' => [
                     '@install-from-git',
                 ],
                 'pre-update-cmd' => [
                     '@install-from-git',
                 ],
-                'post-install-cmd' => [
-                    '@prepare-packages',
-                ],
             ],
         ];
 
@@ -209,94 +193,29 @@ class ComposerGenerator
     }
 
     /**
-     * Adds modules and repositories to composer.json.
+     * Find Composer packages in the folder (recursively)
      *
-     * @param array $repoOptions
-     * @param array $composer
+     * @param string $path
      * @return array
-     * @throws FileSystemException
-     *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     *
-     * @codeCoverageIgnore
      */
-    private function addModules(array $repoOptions, array $composer): array
-    {
-        foreach ($repoOptions as $repoName => $gitOption) {
-            $baseRepoFolder = $this->directoryList->getMagentoRoot() . '/' . $repoName;
-            if ($this->isSinglePackage($gitOption)) {
-                $this->addModule($baseRepoFolder, $composer, '*');
-                continue;
-            }
+    private function findPackages(string $path) {
+        $path = rtrim($path, '\\/');
+        $packageTypes = ['magento2-module', 'magento2-theme', 'magento2-language', 'magento2-library'];
+        $pathLength = strlen($path . '/');
 
-            if ($this->isFlatStructurePackage($gitOption)) {
-                foreach (glob($baseRepoFolder . '/*') as $dir) {
-                    $this->addModule($dir, $composer);
-                }
-                continue;
-            }
+        $repoDirIterator = new \RecursiveDirectoryIterator($path);
+        $recursiveRepoDirIterator = new \RecursiveIteratorIterator($repoDirIterator);
+        $regexIteratorExcludeTests = new \RegexIterator($recursiveRepoDirIterator, '/^((?!test|Test|dev).)*$/', \RegexIterator::MATCH);
+        $regexIterator = new \RegexIterator($regexIteratorExcludeTests, '/composer.json$/', \RegexIterator::MATCH);
 
-            foreach (glob($baseRepoFolder . '/app/code/Magento/*') as $dir) {
-                $this->addModule($dir, $composer);
-            }
-            foreach (glob($baseRepoFolder . '/app/design/*/Magento/*/') as $dir) {
-                $this->addModule($dir, $composer);
-            }
-            foreach (glob($baseRepoFolder . '/app/design/*/Magento/*/') as $dir) {
-                $this->addModule($dir, $composer);
-            }
-            if ($this->file->isDirectory($baseRepoFolder . '/lib/internal/Magento/Framework/')) {
-                foreach (glob($baseRepoFolder . '/lib/internal/Magento/Framework/*') as $dir) {
-                    $this->addModule($dir, $composer);
-                }
+        $packages = [];
+        foreach ($regexIterator as $currentFileInfo) {
+            $packageInfo = json_decode($this->file->fileGetContents($currentFileInfo->getPathName()), true);
+            if (isset($packageInfo['type']) && in_array($packageInfo['type'], $packageTypes)) {
+                $packages[$packageInfo['name']] = substr($currentFileInfo->getPath(), $pathLength);
             }
         }
 
-        return $composer;
-    }
-
-    /**
-     * Add single module to composer json
-     *
-     * @param string $dir
-     * @param array $composer
-     * @param string|null $version
-     * @throws FileSystemException
-     */
-    private function addModule(string $dir, array &$composer, string $version = null): void
-    {
-        if (!$this->file->isExists($dir . '/composer.json')) {
-            return;
-        }
-
-        $dirComposer = json_decode($this->file->fileGetContents($dir . '/composer.json'), true);
-        $composer['repositories'][$dirComposer['name']] = [
-            'type' => 'path',
-            'url' => ltrim(str_replace($this->directoryList->getMagentoRoot(), '', $dir), '/'),
-            'options' => [
-                'symlink' => false,
-            ],
-        ];
-        $composer['require'][$dirComposer['name']] = $version ?? $dirComposer['version'] ?? '*';
-    }
-
-    /**
-     * @param array $repoOptions
-     * @return bool
-     */
-    private function isSinglePackage(array $repoOptions): bool
-    {
-        return isset($repoOptions['type']) && $repoOptions['type'] === self::REPO_TYPE_SINGLE_PACKAGE;
-    }
-
-    /**
-     * Checks that package has option type and it equal to @see ComposerGenerator::REPO_TYPE_FLAT_STRUCTURE
-     *
-     * @param array $repoOptions
-     * @return bool
-     */
-    private function isFlatStructurePackage(array $repoOptions): bool
-    {
-        return isset($repoOptions['type']) && $repoOptions['type'] === self::REPO_TYPE_FLAT_STRUCTURE;
+        return $packages;
     }
 }

--- a/src/Command/Dev/UpdateComposer/clear_module_requirements.php.tpl
+++ b/src/Command/Dev/UpdateComposer/clear_module_requirements.php.tpl
@@ -1,22 +1,15 @@
 <?php
-$repos = array (
-  'package1' => 
-  array (
-    'type' => 'path',
-    'url' => 'repo1/app/code/package1',
-  ),
-  'package2' => 
-  array (
-    'type' => 'path',
-    'url' => 'repo1/app/code/package2',
-  ),
-  'package6' => 
-  array (
-    'type' => 'path',
-    'url' => 'repo2/app/code/package6',
-  ),
-);
-$packages = var_export(array_keys($repos), true);
+
+$composer = json_decode(file_get_contents(__DIR__ . '/composer.json'), true);
+
+if (isset($composer['repositories'])) {
+    $repos = array_filter($composer['repositories'], function($val) {
+       return isset($val['type']) && $val['type'] == 'path';
+    });
+} else {
+    $repos = [];
+}
+$packages = array_keys($repos);
 
 function clearRequirements($dir, $packages) {
     if (!file_exists($dir . '/composer.json')) {

--- a/src/Filesystem/Driver/File.php
+++ b/src/Filesystem/Driver/File.php
@@ -486,6 +486,24 @@ class File
     }
 
     /**
+     * Returns recursive directory iterator for given path with given pattern for files to find
+     *
+     * @param string $dir
+     * @param string $filePattern File pattern to find
+     * @param string $excludePattern Path pattern to exclude
+     * @return \RegexIterator
+     */
+    public function getRecursiveFileIterator(string $dir, string $filePattern, string $excludePattern = ''): \RegexIterator
+    {
+        $dirIterator = new \RecursiveDirectoryIterator($dir);
+        $recursiveDirIterator = new \RecursiveIteratorIterator($dirIterator);
+        if ($excludePattern) {
+            $recursiveDirIterator = new \RegexIterator($recursiveDirIterator, $excludePattern, \RegexIterator::MATCH);
+        }
+        return new \RegexIterator($recursiveDirIterator, $filePattern, \RegexIterator::MATCH);
+    }
+
+    /**
      * @param string $path
      * @return mixed
      */

--- a/src/Test/Unit/Command/Dev/UpdateComposer/ClearModuleRequirementsTest.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/ClearModuleRequirementsTest.php
@@ -68,18 +68,29 @@ class ClearModuleRequirementsTest extends TestCase
             );
 
         $this->clearModuleRequirements->generate([
-            'repo1' => [
-                'branch' => '1.2',
-                'repo' => 'https://token@repo1.com',
+            'package1' => [
+                'type' => 'path',
+                'url' => 'repo1/app/code/package1',
             ],
-            'repo2' => [
-                'branch' => '2.2',
-                'repo' => 'https://token@repo2.com',
+            'package2' => [
+                'type' => 'path',
+                'url' => 'repo1/app/code/package2',
             ],
-            'repo3' => [
-                'branch' => '2.3',
-                'repo' => 'https://token@repo2.com',
-                'type' => 'single-package'
+            'package3' => [
+                'type' => 'composer',
+                'url' => 'https://packagist.org/vendor/package3',
+            ],
+            'package4' => [
+                'type' => 'git',
+                'url' => 'https://token@github.com/vendor/repo.git',
+            ],
+            'package5' => [
+                'type' => 'git',
+                'url' => 'git@github.com:vendor/repo.git',
+            ],
+            'package6' => [
+                'type' => 'path',
+                'url' => 'repo2/app/code/package6',
             ],
         ]);
     }

--- a/src/Test/Unit/Command/Dev/UpdateComposer/ComposerGeneratorTest.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/ComposerGeneratorTest.php
@@ -29,17 +29,15 @@ class ComposerGeneratorTest extends TestCase
         ],
         'repo2' => [
             'repo' => 'path_to_repo2',
-            'branch' => '1.0.0',
+            'branch' => '2.0.0',
         ],
         'repo3' => [
             'repo' => 'path_to_repo3',
             'branch' => '3.0.0',
-            'type' => 'single-package'
         ],
         'repo4' => [
             'repo' => 'path_to_repo4',
-            'branch' => '1.1.0',
-            'type' => 'flat-structure'
+            'branch' => '4.0.0',
         ]
     ];
 
@@ -47,11 +45,6 @@ class ComposerGeneratorTest extends TestCase
      * @var DirectoryList|MockObject
      */
     private $directoryListMock;
-
-    /**
-     * @var File|MockObject
-     */
-    private $fileMock;
 
     /**
      * @var MagentoVersion|MockObject
@@ -69,13 +62,19 @@ class ComposerGeneratorTest extends TestCase
     protected function setUp()
     {
         $this->directoryListMock = $this->createMock(DirectoryList::class);
+        $this->directoryListMock->expects($this->any())
+            ->method('getMagentoRoot')
+            ->willReturn(__DIR__ . '/_files/app');
         $this->magentoVersionMock = $this->createMock(MagentoVersion::class);
-        $this->fileMock = $this->createMock(File::class);
+        $this->magentoVersionMock->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('2.2');
 
         $this->composerGenerator = new ComposerGenerator(
             $this->directoryListMock,
             $this->magentoVersionMock,
-            $this->fileMock
+            new File(),
+            '/^((?!exclude).)*$/'
         );
     }
 
@@ -86,60 +85,13 @@ class ComposerGeneratorTest extends TestCase
 
     public function testGenerate(): void
     {
-        $rootDir = '/root';
-        $this->directoryListMock->expects($this->any())
-            ->method('getMagentoRoot')
-            ->willReturn($rootDir);
-        $this->magentoVersionMock->expects($this->once())
-            ->method('getVersion')
-            ->willReturn('2.2');
-        $this->fileMock->expects($this->exactly(6))
-            ->method('isExists')
-            ->willReturn(true, true, true, true, false, true);
-        $this->fileMock->expects($this->exactly(5))
-            ->method('fileGetContents')
-            ->willReturnOnConsecutiveCalls(
-                '{"require": {"package": "*"}, "repositories": {"repo": {"type": "git", "url": "url"}}}',
-                '{"name": "repo1", "require": {"package/require1": "*"}, "repositories": ' .
-                '{"repo1": {"type": "git", "url": "url"}}}',
-                '{"name": "repo2", "require": {"package/require2": "*", "magento/module-test": ">102.0.0"}, ' .
-                '"repositories": {"repo2": {"type": "git", "url": "url"}}}',
-                '{"name": "repo3", "require": {"package/require3": "*", "magento/framework": ">100.1.1"}, ' .
-                '"repositories": {"repo3": {"type": "git", "url": "url"}}}',
-                '{"name": "repo3", "require": {"package/require3": "*", "magento/framework": ">100.1.1"}, ' .
-                '"repositories": {"repo3": {"type": "git", "url": "url"}}}'
-            );
-
         $composer = $this->composerGenerator->generate($this->repoOptions);
 
-        $this->assertArrayHasKey('version', $composer);
-        $this->assertEquals('2.2', $composer['version']);
-
-        $this->assertArrayHasKey('scripts', $composer);
-        $this->assertArrayHasKey('install-from-git', $composer['scripts']);
-        $this->assertEquals(
-            [
-                "rsync -azh --stats --exclude='app/code/Magento/' --exclude='app/i18n/' --exclude='app/design/'"
-                . " --exclude='dev/tests' --exclude='lib/internal/Magento' --exclude='.git' ./repo1/ ./",
-                "rsync -azh --stats --exclude='app/code/Magento/' --exclude='app/i18n/' --exclude='app/design/'"
-                . " --exclude='dev/tests' --exclude='lib/internal/Magento' --exclude='.git' ./repo2/ ./",
-            ],
-            $composer['scripts']['prepare-packages']
-        );
-        $this->assertInstallFromGitScripts($composer['scripts']['install-from-git']);
-
-        $this->assertArrayHasKey('require', $composer);
-        $this->assertArrayHasKey('package/require1', $composer['require']);
-        $this->assertArrayHasKey('package/require2', $composer['require']);
-        $this->assertArrayHasKey('package/require3', $composer['require']);
-        $this->assertArrayHasKey('magento/framework', $composer['require']);
-        $this->assertArrayHasKey('magento/module-test', $composer['require']);
-
-        $this->assertEquals('*', $composer['require']['magento/framework']);
-        $this->assertEquals('*', $composer['require']['magento/module-test']);
-
-        $this->assertArrayHasKey('repositories', $composer);
-        $this->assertArrayHasKey('repo3', $composer['repositories']);
+        $expected = include(__DIR__ . '/_files/expected_composer.php');
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $composer);
+            $this->assertEquals($value, $composer[$key]);
+        }
     }
 
     /**
@@ -153,10 +105,10 @@ class ComposerGeneratorTest extends TestCase
             [
                 'php -r"@mkdir(__DIR__ . \'/app/etc\', 0777, true);"',
                 'rm -rf repo1 repo2 repo3 repo4',
-                'git clone -b 1.0.0 --single-branch --depth 1 path_to_repo1 repo1',
-                'git clone -b 1.0.0 --single-branch --depth 1 path_to_repo2 repo2',
-                'git clone -b 3.0.0 --single-branch --depth 1 path_to_repo3 repo3',
-                'git clone -b 1.1.0 --single-branch --depth 1 path_to_repo4 repo4',
+                'git clone path_to_repo1 "repo1" && git --git-dir="repo1/.git" --work-tree="repo1" checkout 1.0.0',
+                'git clone path_to_repo2 "repo2" && git --git-dir="repo2/.git" --work-tree="repo2" checkout 2.0.0',
+                'git clone path_to_repo3 "repo3" && git --git-dir="repo3/.git" --work-tree="repo3" checkout 3.0.0',
+                'git clone path_to_repo4 "repo4" && git --git-dir="repo4/.git" --work-tree="repo4" checkout 4.0.0',
             ],
             $actual
         );

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/composer.json
@@ -1,0 +1,11 @@
+{
+  "require": {
+    "package": "*"
+  },
+  "repositories": {
+    "repo": {
+      "type": "git",
+      "url": "url"
+    }
+  }
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "repo1",
+  "require": {
+    "package/require1": "*"
+  },
+  "repositories": {
+    "repo1": {
+      "type": "git",
+      "url": "url"
+    }
+  }
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/lib/internal/Vendor/Library1/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/lib/internal/Vendor/Library1/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor/library1",
+  "type": "magento2-library"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/package/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo1/package/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor/project",
+  "type": "project"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/app/code/Vendor/Module1/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/app/code/Vendor/Module1/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor/module-module1",
+  "type": "magento2-module"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/app/design/Vendor/Theme1/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/app/design/Vendor/Theme1/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor/theme1",
+  "type": "magento2-theme"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "repo2",
+  "require": {
+    "package/require2": "*",
+    "magento/module-test": ">102.0.0"
+  },
+  "repositories": {
+    "repo2": {
+      "type": "git",
+      "url": "url"
+    }
+  }
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/exclude/package/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo2/exclude/package/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "exclude/package",
+  "type": "magento2-module"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo3/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo3/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "repo3",
+  "require": {
+    "package/require3": "*",
+    "magento/framework": ">100.1.1"
+  },
+  "repositories": {
+    "repo3": {
+      "type": "git",
+      "url": "url"
+    }
+  }
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo3/package/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo3/package/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor/metapackage",
+  "type": "metapackage"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo4/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo4/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "repo4",
+  "require": {
+    "package/require4": "*",
+    "magento/framework": ">100.1.1"
+  },
+  "repositories": {
+    "repo4": {
+      "type": "git",
+      "url": "url"
+    }
+  }
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo4/package/composer.json
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/app/repo4/package/composer.json
@@ -1,0 +1,5 @@
+{
+  "name": "vendor/library",
+  "type": "library",
+  "description": "Library"
+}

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/clear_module_requirements.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/clear_module_requirements.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
 $repos = array (
   'package1' => 
   array (

--- a/src/Test/Unit/Command/Dev/UpdateComposer/_files/expected_composer.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposer/_files/expected_composer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+return array(
+    'version' => '2.2',
+    'repositories' => [
+        'repo' =>  [
+            'type' => 'git',
+            'url' => 'url',
+        ],
+        'vendor/library1' => [
+            'type' => 'path',
+            'url' => 'repo1/lib/internal/Vendor/Library1',
+            'options' => [
+                'symlink' => false,
+            ],
+        ],
+        'vendor/module-module1' => [
+            'type' => 'path',
+            'url' => 'repo2/app/code/Vendor/Module1',
+            'options' => [
+                'symlink' => false,
+            ],
+        ],
+        'vendor/theme1' => [
+            'type' => 'path',
+            'url' => 'repo2/app/design/Vendor/Theme1',
+            'options' => [
+                'symlink' => false,
+            ],
+        ],
+    ],
+    'require' => [
+        'package' => '*',
+        'vendor/library1' => '*@dev',
+        'vendor/theme1' => '*@dev',
+        'vendor/module-module1' => '*@dev',
+    ],
+    'scripts' =>[
+        'install-from-git' => [
+            'php -r"@mkdir(__DIR__ . \'/app/etc\', 0777, true);"',
+            'rm -rf repo1 repo2 repo3 repo4',
+            'git clone path_to_repo1 "repo1" && git --git-dir="repo1/.git" --work-tree="repo1" checkout 1.0.0',
+            'git clone path_to_repo2 "repo2" && git --git-dir="repo2/.git" --work-tree="repo2" checkout 2.0.0',
+            'git clone path_to_repo3 "repo3" && git --git-dir="repo3/.git" --work-tree="repo3" checkout 3.0.0',
+            'git clone path_to_repo4 "repo4" && git --git-dir="repo4/.git" --work-tree="repo4" checkout 4.0.0',
+        ],
+        'pre-install-cmd' => [
+            '@install-from-git',
+        ],
+        'pre-update-cmd' => [
+            '@install-from-git',
+        ],
+        'prepare-packages' => [
+            'rsync -azhm --stats --exclude=\'lib/internal/Vendor/Library1\' --exclude=\'dev/tests\' --exclude=\'.git\' --exclude=\'composer.json\' --exclude=\'composer.lock\' ./repo1/ ./',
+            'rsync -azhm --stats --exclude=\'app/design/Vendor/Theme1\' --exclude=\'app/code/Vendor/Module1\' --exclude=\'dev/tests\' --exclude=\'.git\' --exclude=\'composer.json\' --exclude=\'composer.lock\' ./repo2/ ./',
+            'rsync -azhm --stats --exclude=\'dev/tests\' --exclude=\'.git\' --exclude=\'composer.json\' --exclude=\'composer.lock\' ./repo3/ ./',
+            'rsync -azhm --stats --exclude=\'dev/tests\' --exclude=\'.git\' --exclude=\'composer.json\' --exclude=\'composer.lock\' ./repo4/ ./',
+        ],
+        'post-install-cmd' => [
+            '@prepare-packages',
+        ],
+    ],
+);

--- a/src/Test/Unit/Command/Dev/UpdateComposerTest.php
+++ b/src/Test/Unit/Command/Dev/UpdateComposerTest.php
@@ -109,7 +109,17 @@ class UpdateComposerTest extends TestCase
             ->method('generate')
             ->with($gitOptions['repositories'])
             ->willReturn([
-                'name' => 'magento/cloud'
+                'name' => 'magento/cloud',
+                'repositories' => [
+                    'vendor1/package1' => [
+                        'type' => 'path',
+                        'url' => 'repo1'
+                    ],
+                    'vendor2/package2' => [
+                        'type' => 'path',
+                        'url' => 'repo2'
+                    ],
+                ],
             ]);
         $this->shellMock->expects($this->exactly(3))
             ->method('execute')


### PR DESCRIPTION
### Description

1. Adding support for arbitrary structure of repositories w/o necessity to specify type of the repository manually.
2. Added support for any Git ref (not only "branch"). `.magento.env.yaml` now would allow the following structure:
```
      repositories:
        ce:
          ref: d69c242d9033616cd88018eea97f3a19bbc2da70
          repo: https://${GITHUB_TOKEN}@github.com/magento/magento2ce.git
        ee:
          repo: https://${GITHUB_TOKEN}@github.com/magento/magento2ee.git
          branch: 2.4-develop
```

`branch` is left for backwards compatibility. Branch can be specified in `ref` field as well. `ref` has precedence over `branch`.

### Fixed Issues (if relevant)

Also fixed an issue with the application located in `/app` folder - in this case "app" has been unnecessary removed twice from paths like `/app/app/code/Magento/...".

### Manual testing scenarios

Based on steps for Git-based installation on Cloud (https://wiki.corp.magento.com/pages/viewpage.action?spaceKey=MCP&title=ECE+Tools+-+Simple+Flow+to+Deploy+Magento+to+ECE+from+GitHub+Branch)

1. Specify repos with different structure in `.magento.env.yaml` (e.g., CE, EE, B2B, inventory, catalog-storefront-ce/ee)
2. Run `./bin/magento dev:git:update-composer`

Expected: 1) all Magento packages present in the specified repos are cloned and linked via Composer repo type `path` in the generated `composer.json`; 2) project files (such as `index.php`, `pub/`) are copied to the root of the project.

### Example Results

* Example generated `composer.json` - https://git.corp.adobe.com/ecp/magento-cloud/blob/production/composer.json
   * Generated by build https://magento-ecp.ci.corp.adobe.com/view/Build/job/build-magento-cloud-project/job/production/75/
   * Successfully deployed to Cloud project - https://magento-ecp.ci.corp.adobe.com/view/Deploy/job/deploy-magento-cloud/job/production/26/

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
